### PR TITLE
Fix issue "This plugin threw an error from the characteristic 'Name'"

### DIFF
--- a/src/serviceManager.ts
+++ b/src/serviceManager.ts
@@ -49,7 +49,7 @@ class ServiceManager {
       assert(bind, 'A value for `bind` is required if you are setting `props`')
       this.getCharacteristic(type).on(getSet, method.bind(bind, props));
     } else {
-      const boundMethod = bind ? method.bind(bind) : method
+      const boundMethod = bind ? method.bind(bind) : method.bind(this)
       this.getCharacteristic(type).on(getSet, boundMethod);
     }
   }


### PR DESCRIPTION
[homebridge-broadlink-rm] This plugin threw an error from the characteristic 'Name': Unhandled error thrown inside read handler for characteristic: log is not a function. See https://git.io/JtMGR for more info.
[homebridge-broadlink-rm] TypeError: log is not a function
    at Name.getName (/usr/local/lib/node_modules/homebridge-broadlink-rm/node_modules/homebridge-platform-helper/dist/serviceManager.js:69:9)
    at Name.emit (events.js:314:20)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Characteristic.js:733:43
    at new Promise (<anonymous>:null:null)
    at Name.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Characteristic.js:731:47)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:143:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:124:57)
    at /usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>:null:null)
    at Object.__awaiter (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:113:16)
    at Name.Characteristic.handleGetRequest (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Characteristic.js:656:24)
    at Name.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Characteristic.js:1310:51)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:143:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:124:57)
    at /usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>:null:null)
    at Object.__awaiter (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:113:16)
    at Name.Characteristic.toHAP (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Characteristic.js:1293:24)
    at _loop_1 (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Service.js:432:32)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Service.js:450:21
    at new Promise (<anonymous>:null:null)
    at Thermostat.Service.toHAP (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Service.js:356:16)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Accessory.js:827:112
    at Array.map (<anonymous>:null:null)
    at Accessory.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Accessory.js:827:72)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:143:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:124:57)
    at /usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>:null:null)
    at Object.__awaiter (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:113:16)
    at Accessory.toHAP (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Accessory.js:816:24)
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Accessory.js:837:78
    at Array.map (<anonymous>:null:null)
    at Bridge.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/dist/lib/Accessory.js:837:34)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:143:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:124:57)
    at fulfilled (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:114:62)
    at runMicrotasks (<anonymous>:null:null)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)